### PR TITLE
Enable multi node multi gpu training

### DIFF
--- a/nnunetv2/run/load_pretrained_weights.py
+++ b/nnunetv2/run/load_pretrained_weights.py
@@ -1,3 +1,5 @@
+import os
+
 import torch
 from torch._dynamo import OptimizedModule
 from torch.nn.parallel import DistributedDataParallel as DDP
@@ -17,7 +19,7 @@ def load_pretrained_weights(network, fname, verbose=False):
 
     """
     if dist.is_initialized():
-        saved_model = torch.load(fname, map_location=torch.device('cuda', dist.get_rank()))
+        saved_model = torch.load(fname, map_location=torch.device('cuda', int(os.environ["LOCAL_RANK"])))
     else:
         saved_model = torch.load(fname)
     pretrained_dict = saved_model['network_weights']

--- a/nnunetv2/run/run_training.py
+++ b/nnunetv2/run/run_training.py
@@ -1,32 +1,19 @@
-import multiprocessing
 import os
-import socket
+import sys
+import warnings
 from typing import Union, Optional
 
-import nnunetv2
 import torch.cuda
 import torch.distributed as dist
-import torch.multiprocessing as mp
 from batchgenerators.utilities.file_and_folder_operations import join, isfile, load_json
+from torch.backends import cudnn
+
+import nnunetv2
 from nnunetv2.paths import nnUNet_preprocessed
 from nnunetv2.run.load_pretrained_weights import load_pretrained_weights
 from nnunetv2.training.nnUNetTrainer.nnUNetTrainer import nnUNetTrainer
 from nnunetv2.utilities.dataset_name_id_conversion import maybe_convert_to_dataset_name
 from nnunetv2.utilities.find_class_by_name import recursive_find_python_class
-from torch.backends import cudnn
-
-
-def find_free_network_port() -> int:
-    """Finds a free port on localhost.
-
-    It is useful in single-node training when we don't want to connect to a real main node but have to set the
-    `MASTER_PORT` environment variable.
-    """
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("", 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
 
 
 def get_trainer_from_args(dataset_name_or_id: Union[int, str],
@@ -35,17 +22,18 @@ def get_trainer_from_args(dataset_name_or_id: Union[int, str],
                           trainer_name: str = 'nnUNetTrainer',
                           plans_identifier: str = 'nnUNetPlans',
                           use_compressed: bool = False,
+                          use_zero_optimizer: bool = False,
                           device: torch.device = torch.device('cuda')):
     # load nnunet class and do sanity checks
     nnunet_trainer = recursive_find_python_class(join(nnunetv2.__path__[0], "training", "nnUNetTrainer"),
-                                                trainer_name, 'nnunetv2.training.nnUNetTrainer')
+                                                 trainer_name, 'nnunetv2.training.nnUNetTrainer')
     if nnunet_trainer is None:
         raise RuntimeError(f'Could not find requested nnunet trainer {trainer_name} in '
                            f'nnunetv2.training.nnUNetTrainer ('
                            f'{join(nnunetv2.__path__[0], "training", "nnUNetTrainer")}). If it is located somewhere '
                            f'else, please move it there.')
     assert issubclass(nnunet_trainer, nnUNetTrainer), 'The requested nnunet trainer class must inherit from ' \
-                                                    'nnUNetTrainer'
+                                                      'nnUNetTrainer'
 
     # handle dataset input. If it's an ID we need to convert to int from string
     if dataset_name_or_id.startswith('Dataset'):
@@ -64,11 +52,14 @@ def get_trainer_from_args(dataset_name_or_id: Union[int, str],
     plans = load_json(plans_file)
     dataset_json = load_json(join(preprocessed_dataset_folder_base, 'dataset.json'))
     nnunet_trainer = nnunet_trainer(plans=plans, configuration=configuration, fold=fold,
-                                    dataset_json=dataset_json, unpack_dataset=not use_compressed, device=device)
+                                    dataset_json=dataset_json, unpack_dataset=not use_compressed, device=device,
+                                    use_zero_optimizer=use_zero_optimizer)
     return nnunet_trainer
 
 
-def maybe_load_checkpoint(nnunet_trainer: nnUNetTrainer, continue_training: bool, validation_only: bool,
+def maybe_load_checkpoint(nnunet_trainer: nnUNetTrainer,
+                          continue_training: bool,
+                          validation_only: bool,
                           pretrained_weights_file: str = None):
     if continue_training and pretrained_weights_file is not None:
         raise RuntimeError('Cannot both continue a training AND load pretrained weights. Pretrained weights can only '
@@ -82,7 +73,7 @@ def maybe_load_checkpoint(nnunet_trainer: nnUNetTrainer, continue_training: bool
             expected_checkpoint_file = join(nnunet_trainer.output_folder, 'checkpoint_best.pth')
         if not isfile(expected_checkpoint_file):
             print(f"WARNING: Cannot continue training because there seems to be no checkpoint available to "
-                               f"continue from. Starting a new training...")
+                  f"continue from. Starting a new training...")
             expected_checkpoint_file = None
     elif validation_only:
         expected_checkpoint_file = join(nnunet_trainer.output_folder, 'checkpoint_final.pth')
@@ -99,56 +90,21 @@ def maybe_load_checkpoint(nnunet_trainer: nnUNetTrainer, continue_training: bool
         nnunet_trainer.load_checkpoint(expected_checkpoint_file)
 
 
-def setup_ddp(rank, world_size):
-    # initialize the process group
-    dist.init_process_group("nccl", rank=rank, world_size=world_size)
-
-
-def cleanup_ddp():
-    dist.destroy_process_group()
-
-
-def run_ddp(rank, dataset_name_or_id, configuration, fold, tr, p, use_compressed, disable_checkpointing, c, val,
-            pretrained_weights, npz, val_with_best, world_size):
-    setup_ddp(rank, world_size)
-    torch.cuda.set_device(torch.device('cuda', dist.get_rank()))
-
-    nnunet_trainer = get_trainer_from_args(dataset_name_or_id, configuration, fold, tr, p,
-                                           use_compressed)
-
-    if disable_checkpointing:
-        nnunet_trainer.disable_checkpointing = disable_checkpointing
-
-    assert not (c and val), f'Cannot set --c and --val flag at the same time. Dummy.'
-
-    maybe_load_checkpoint(nnunet_trainer, c, val, pretrained_weights)
-
-    if torch.cuda.is_available():
-        cudnn.deterministic = False
-        cudnn.benchmark = True
-
-    if not val:
-        nnunet_trainer.run_training()
-
-    if val_with_best:
-        nnunet_trainer.load_checkpoint(join(nnunet_trainer.output_folder, 'checkpoint_best.pth'))
-    nnunet_trainer.perform_actual_validation(npz)
-    cleanup_ddp()
-
-
 def run_training(dataset_name_or_id: Union[str, int],
-                 configuration: str, fold: Union[int, str],
+                 configuration: str,
+                 fold: Union[int, str],
+                 compute_device: str,
+                 backend: str,
                  trainer_class_name: str = 'nnUNetTrainer',
                  plans_identifier: str = 'nnUNetPlans',
                  pretrained_weights: Optional[str] = None,
-                 num_gpus: int = 1,
                  use_compressed_data: bool = False,
                  export_validation_probabilities: bool = False,
                  continue_training: bool = False,
                  only_run_validation: bool = False,
                  disable_checkpointing: bool = False,
                  val_with_best: bool = False,
-                 device: torch.device = torch.device('cuda')):
+                 use_zero_optimizer: bool = False):
     if plans_identifier == 'nnUNetPlans':
         print("\n############################\n"
               "INFO: You are using the old nnU-Net default plans. We have updated our recommendations. "
@@ -160,62 +116,49 @@ def run_training(dataset_name_or_id: Union[str, int],
             try:
                 fold = int(fold)
             except ValueError as e:
-                print(f'Unable to convert given value for fold to int: {fold}. fold must bei either "all" or an integer!')
+                print(
+                    f'Unable to convert given value for fold to int: {fold}. fold must bei either "all" or an integer!')
                 raise e
 
     if val_with_best:
         assert not disable_checkpointing, '--val_best is not compatible with --disable_checkpointing'
 
-    if num_gpus > 1:
-        assert device.type == 'cuda', f"DDP training (triggered by num_gpus > 1) is only implemented for cuda devices. Your device: {device}"
+    assert not (continue_training and only_run_validation), f'Cannot set --c and --val flag at the same time.'
 
-        os.environ['MASTER_ADDR'] = 'localhost'
-        if 'MASTER_PORT' not in os.environ.keys():
-            port = str(find_free_network_port())
-            print(f"using port {port}")
-            os.environ['MASTER_PORT'] = port  # str(port)
+    if compute_device in ['cuda', 'cpu']:
+        dist.init_process_group(backend=backend)
+    device = torch.device(compute_device, int(os.environ["LOCAL_RANK"]))
 
-        mp.spawn(run_ddp,
-                 args=(
-                     dataset_name_or_id,
-                     configuration,
-                     fold,
-                     trainer_class_name,
-                     plans_identifier,
-                     use_compressed_data,
-                     disable_checkpointing,
-                     continue_training,
-                     only_run_validation,
-                     pretrained_weights,
-                     export_validation_probabilities,
-                     val_with_best,
-                     num_gpus),
-                 nprocs=num_gpus,
-                 join=True)
-    else:
-        nnunet_trainer = get_trainer_from_args(dataset_name_or_id, configuration, fold, trainer_class_name,
-                                               plans_identifier, use_compressed_data, device=device)
+    nnunet_trainer = get_trainer_from_args(dataset_name_or_id, configuration, fold, trainer_class_name,
+                                           plans_identifier, use_compressed_data, use_zero_optimizer, device)
 
-        if disable_checkpointing:
-            nnunet_trainer.disable_checkpointing = disable_checkpointing
+    if disable_checkpointing:
+        nnunet_trainer.disable_checkpointing = disable_checkpointing
 
-        assert not (continue_training and only_run_validation), f'Cannot set --c and --val flag at the same time. Dummy.'
+    maybe_load_checkpoint(nnunet_trainer, continue_training, only_run_validation, pretrained_weights)
 
-        maybe_load_checkpoint(nnunet_trainer, continue_training, only_run_validation, pretrained_weights)
+    if torch.cuda.is_available():
+        cudnn.deterministic = False
+        cudnn.benchmark = True
 
-        if torch.cuda.is_available():
-            cudnn.deterministic = False
-            cudnn.benchmark = True
+    if not only_run_validation:
+        nnunet_trainer.run_training()
 
-        if not only_run_validation:
-            nnunet_trainer.run_training()
+    if val_with_best:
+        nnunet_trainer.load_checkpoint(join(nnunet_trainer.output_folder, 'checkpoint_best.pth'))
+    nnunet_trainer.perform_actual_validation(export_validation_probabilities)
 
-        if val_with_best:
-            nnunet_trainer.load_checkpoint(join(nnunet_trainer.output_folder, 'checkpoint_best.pth'))
-        nnunet_trainer.perform_actual_validation(export_validation_probabilities)
+    if dist.is_available():
+        dist.destroy_process_group()
 
 
 def run_training_entry():
+    """
+    This is the entry point for training nnU-Net. This function is called when running the command `nnUNetv2_train`.
+    However, for fault-tolerant execution, this script should be called using `torchrun` command.
+    For details of torchrun, refer here https://pytorch.org/docs/stable/elastic/run.html#elastic-min-1-max-4-tolerates-up-to-3-membership-changes-or-failures
+    When CUDA is enabled, DDP is used for multi node, multi gpu training. `torchrun` launches a python process for each GPU.
+    """
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument('dataset_name_or_id', type=str,
@@ -231,8 +174,6 @@ def run_training_entry():
     parser.add_argument('-pretrained_weights', type=str, required=False, default=None,
                         help='[OPTIONAL] path to nnU-Net checkpoint file to be used as pretrained model. Will only '
                              'be used when actually training. Beta. Use with caution.')
-    parser.add_argument('-num_gpus', type=int, default=1, required=False,
-                        help='Specify the number of GPUs to use for training')
     parser.add_argument("--use_compressed", default=False, action="store_true", required=False,
                         help="[OPTIONAL] If you set this flag the training cases will not be decompressed. Reading compressed "
                              "data is much more CPU and (potentially) RAM intensive and should only be used if you "
@@ -240,7 +181,7 @@ def run_training_entry():
     parser.add_argument('--npz', action='store_true', required=False,
                         help='[OPTIONAL] Save softmax predictions from final validation as npz files (in addition to predicted '
                              'segmentations). Needed for finding the best ensemble.')
-    parser.add_argument('--c', action='store_true', required=False,
+    parser.add_argument('--continue_from_checkpoint', action='store_true', required=False,
                         help='[OPTIONAL] Continue training from latest checkpoint')
     parser.add_argument('--val', action='store_true', required=False,
                         help='[OPTIONAL] Set this flag to only run the validation. Requires training to have finished.')
@@ -252,29 +193,31 @@ def run_training_entry():
     parser.add_argument('--disable_checkpointing', action='store_true', required=False,
                         help='[OPTIONAL] Set this flag to disable checkpointing. Ideal for testing things out and '
                              'you dont want to flood your hard drive with checkpoints.')
-    parser.add_argument('-device', type=str, default='cuda', required=False,
-                    help="Use this to set the device the training should run with. Available options are 'cuda' "
-                         "(GPU), 'cpu' (CPU) and 'mps' (Apple M1/M2). Do NOT use this to set which GPU ID! "
-                         "Use CUDA_VISIBLE_DEVICES=X nnUNetv2_train [...] instead!")
+    parser.add_argument('--use_zero_optimizer', action='store_true', default=False, required=False,
+                        help="[OPTIONAL] Use ZeroRedundancyOptimizer for distributed training. Default false.")
+    parser.add_argument('--device', type=str, default='cuda', required=False,
+                        help="[OPTIONAL] Use this to set the device the training should run with. Available options are "
+                             "'cuda' (GPU), 'cpu' (CPU) and 'mps' (Apple M1/M2). ")
+    parser.add_argument('--backend', type=str, default='nccl', required=False,
+                        help="Set the backend to use for distributed training. Available options are "
+                             "'mpi', 'nccl' or 'gloo'. 'nccl' can only be used with CUDA.")
     args = parser.parse_args()
 
-    assert args.device in ['cpu', 'cuda', 'mps'], f'-device must be either cpu, mps or cuda. Other devices are not tested/supported. Got: {args.device}.'
-    if args.device == 'cpu':
-        # let's allow torch to use hella threads
-        import multiprocessing
-        torch.set_num_threads(multiprocessing.cpu_count())
-        device = torch.device('cpu')
-    elif args.device == 'cuda':
+    assert args.device in ['cpu', 'cuda', 'mps'], \
+        f'--device must be either cpu, mps or cuda. Other devices are not tested/supported. Got: {args.device}.'
+    if args.device in ['cpu', 'mps'] and args.backend not in ['mpi', 'gloo']:
+        sys.exit('CPU and MPS can only use MPI or Gloo backend.')
+    elif args.device == 'cuda' and args.backend != 'nccl':
+        warnings.warn('For highest performance use CUDA with NCCL backend.')
+
+    if args.device == 'cuda':
         # multithreading in torch doesn't help nnU-Net if run on GPU
         torch.set_num_threads(1)
         torch.set_num_interop_threads(1)
-        device = torch.device('cuda')
-    else:
-        device = torch.device('mps')
 
-    run_training(args.dataset_name_or_id, args.configuration, args.fold, args.tr, args.p, args.pretrained_weights,
-                 args.num_gpus, args.use_compressed, args.npz, args.c, args.val, args.disable_checkpointing, args.val_best,
-                 device=device)
+    run_training(args.dataset_name_or_id, args.configuration,  args.fold, args.device, args.backend, args.tr, args.p,
+                 args.pretrained_weights, args.use_compressed, args.npz, args.continue_from_checkpoint, args.val,
+                 args.disable_checkpointing, args.val_best, args.use_zero_optimizer)
 
 
 if __name__ == '__main__':

--- a/nnunetv2/training/dataloading/elastic_data_loader_2d.py
+++ b/nnunetv2/training/dataloading/elastic_data_loader_2d.py
@@ -1,0 +1,34 @@
+from typing import Union, Tuple, List
+
+import numpy as np
+
+from nnunetv2.training.dataloading.data_loader_2d import nnUNetDataLoader2D
+from nnunetv2.training.dataloading.elastic_data_sampler import nnUNetElasticDataSampler
+from nnunetv2.training.dataloading.nnunet_dataset import nnUNetDataset
+from nnunetv2.utilities.label_handling.label_handling import LabelManager
+
+
+class nnUNetElasticDataLoader2D(nnUNetDataLoader2D):
+    def __init__(self, data: nnUNetDataset, batch_size: int, patch_size: Union[List[int], Tuple[int, ...], np.ndarray],
+                 final_patch_size: Union[List[int], Tuple[int, ...], np.ndarray], label_manager: LabelManager,
+                 oversample_foreground_percent: float = 0.0,
+                 sampling_probabilities: Union[List[int], Tuple[int, ...], np.ndarray] = None,
+                 pad_sides: Union[List[int], Tuple[int, ...], np.ndarray] = None,
+                 probabilistic_oversampling: bool = False, transforms=None, num_replicas=None, rank=None,
+                 start_index=0):
+        super().__init__(data, batch_size, patch_size, final_patch_size, label_manager, oversample_foreground_percent,
+                         sampling_probabilities, pad_sides, probabilistic_oversampling, transforms)
+        self._dataset_sampler = nnUNetElasticDataSampler(data, num_replicas, rank, start_index)
+        selected_indices = self._dataset_sampler.get_dataset_bounds()
+        self.indices = [key for idx, key in enumerate(self._data.keys()) if idx in selected_indices]
+
+    def get_indices(self):
+        selected_indices = self._dataset_sampler.get_dataset_bounds()
+        self.indices = [key for idx, key in enumerate(self._data.keys()) if idx in selected_indices]
+        return super().get_indices()
+
+    def set_epoch(self, epoch):
+        self._dataset_sampler.set_epoch(epoch)
+
+    def __len__(self):
+        return self._dataset_sampler.__len__()

--- a/nnunetv2/training/dataloading/elastic_data_loader_3d.py
+++ b/nnunetv2/training/dataloading/elastic_data_loader_3d.py
@@ -1,0 +1,34 @@
+from typing import Union, List, Tuple
+
+import numpy as np
+
+from nnunetv2.training.dataloading.data_loader_3d import nnUNetDataLoader3D
+from nnunetv2.training.dataloading.elastic_data_sampler import nnUNetElasticDataSampler
+from nnunetv2.training.dataloading.nnunet_dataset import nnUNetDataset
+from nnunetv2.utilities.label_handling.label_handling import LabelManager
+
+
+class nnUNetElasticDataLoader3D(nnUNetDataLoader3D):
+    def __init__(self, data: nnUNetDataset, batch_size: int, patch_size: Union[List[int], Tuple[int, ...], np.ndarray],
+                 final_patch_size: Union[List[int], Tuple[int, ...], np.ndarray], label_manager: LabelManager,
+                 oversample_foreground_percent: float = 0.0,
+                 sampling_probabilities: Union[List[int], Tuple[int, ...], np.ndarray] = None,
+                 pad_sides: Union[List[int], Tuple[int, ...], np.ndarray] = None,
+                 probabilistic_oversampling: bool = False, transforms=None, num_replicas=None, rank=None,
+                 start_index=0):
+        super().__init__(data, batch_size, patch_size, final_patch_size, label_manager, oversample_foreground_percent,
+                         sampling_probabilities, pad_sides, probabilistic_oversampling, transforms)
+        self._dataset_sampler = nnUNetElasticDataSampler(data, num_replicas, rank, start_index)
+        selected_indices = self._dataset_sampler.get_dataset_bounds()
+        self.indices = [key for idx, key in enumerate(self._data.keys()) if idx in selected_indices]
+
+    def get_indices(self):
+        selected_indices = self._dataset_sampler.get_dataset_bounds()
+        self.indices = [key for idx, key in enumerate(self._data.keys()) if idx in selected_indices]
+        return super().get_indices()
+
+    def set_epoch(self, epoch):
+        self._dataset_sampler.set_epoch(epoch)
+
+    def __len__(self):
+        return self._dataset_sampler.__len__()

--- a/nnunetv2/training/dataloading/elastic_data_sampler.py
+++ b/nnunetv2/training/dataloading/elastic_data_sampler.py
@@ -1,0 +1,55 @@
+import os
+from typing import Optional
+
+import numpy as np
+import torch
+
+from nnunetv2.training.dataloading.nnunet_dataset import nnUNetDataset
+
+
+class nnUNetElasticDataSampler(object):
+    """
+    A data sampler based on PyTorch's :class:`torch.utils.data.ElasticDatasetSampler` to handle distributed training.
+    It loads a subset of data from the original dataset that is exclusive to the current process.
+    """
+    def __init__(self, dataset: nnUNetDataset, num_replicas: Optional[int] = None, rank: Optional[int] = None,
+                 start_index: int = 0):
+        if start_index >= len(dataset):
+            raise ValueError(f"Start index {start_index} should be less than dataset size {len(dataset)}")
+
+        self._dataset = dataset
+        if num_replicas is None:
+            self.num_replicas = int(os.environ['WORLD_SIZE'])
+        if rank is None:
+            self.rank = int(os.environ['RANK'])
+        self.start_index = start_index
+        self.epoch = 0
+        self.num_samples = int(np.ceil(float(len(self._dataset) - self.start_index) / self.num_replicas))
+        self.total_size = self.num_samples * self.num_replicas
+
+    def get_dataset_bounds(self) -> list[int]:
+        # Shuffle data deterministically based on current epoch
+        gen = torch.Generator()
+        gen.manual_seed(self.epoch)
+        next_indices = (
+            torch.randperm(len(self._dataset) - self.start_index, generator=gen).add(self.start_index).tolist()
+        )
+
+        # Add extra samples to make it evenly divisible
+        next_indices += next_indices[: (self.total_size - len(next_indices))]
+        assert len(next_indices) == self.total_size
+
+        # Pick a subsample
+        selected_indices = next_indices[self.rank: self.total_size: self.num_replicas]
+        assert len(selected_indices) == self.num_samples
+        return selected_indices
+
+    def set_epoch(self, epoch):
+        """
+        If shuffle in data is required, ensure this method is called at the beginning of each epoch to guarantee
+        data is randomized. Otherwise, each epoch will have the same ordering.
+        """
+        self.epoch = epoch
+
+    def __len__(self):
+        return self.num_samples

--- a/nnunetv2/training/dataloading/nnunet_dataset.py
+++ b/nnunetv2/training/dataloading/nnunet_dataset.py
@@ -83,7 +83,7 @@ class nnUNetDataset(object):
             data = entry['open_data_file']
             # print('using open data file')
         elif isfile(entry['data_file'][:-4] + ".npy"):
-            data = np.load(entry['data_file'][:-4] + ".npy", 'r')
+            data = np.load(entry['data_file'][:-4] + ".npy", 'r+')
             if self.keep_files_open:
                 self.dataset[key]['open_data_file'] = data
                 # print('saving open data file')
@@ -94,7 +94,7 @@ class nnUNetDataset(object):
             seg = entry['open_seg_file']
             # print('using open data file')
         elif isfile(entry['data_file'][:-4] + "_seg.npy"):
-            seg = np.load(entry['data_file'][:-4] + "_seg.npy", 'r')
+            seg = np.load(entry['data_file'][:-4] + "_seg.npy", 'r+')
             if self.keep_files_open:
                 self.dataset[key]['open_seg_file'] = seg
                 # print('saving open seg file')
@@ -103,7 +103,7 @@ class nnUNetDataset(object):
 
         if 'seg_from_prev_stage_file' in entry.keys():
             if isfile(entry['seg_from_prev_stage_file'][:-4] + ".npy"):
-                seg_prev = np.load(entry['seg_from_prev_stage_file'][:-4] + ".npy", 'r')
+                seg_prev = np.load(entry['seg_from_prev_stage_file'][:-4] + ".npy", 'r+')
             else:
                 seg_prev = np.load(entry['seg_from_prev_stage_file'])['seg']
             seg = np.vstack((seg, seg_prev[None]))

--- a/nnunetv2/training/lr_scheduler/polylr.py
+++ b/nnunetv2/training/lr_scheduler/polylr.py
@@ -1,7 +1,7 @@
-from torch.optim.lr_scheduler import _LRScheduler
+from torch.optim.lr_scheduler import LRScheduler
 
 
-class PolyLRScheduler(_LRScheduler):
+class PolyLRScheduler(LRScheduler):
     def __init__(self, optimizer, initial_lr: float, max_steps: int, exponent: float = 0.9, current_step: int = None):
         self.optimizer = optimizer
         self.initial_lr = initial_lr

--- a/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerTopkLoss.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerTopkLoss.py
@@ -55,7 +55,7 @@ class nnUNetTrainerDiceTopK10Loss(nnUNetTrainer):
     def _build_loss(self):
         assert not self.label_manager.has_regions, "regions not supported by this trainer"
         loss = DC_and_topk_loss(
-            {"batch_dice": self.configuration_manager.batch_dice, "smooth": 1e-5, "do_bg": False, "ddp": self.is_ddp},
+            {"batch_dice": self.configuration_manager.batch_dice, "smooth": 1e-5, "do_bg": False, 'ddp': self.is_ddp},
             {"k": 10, "label_smoothing": 0.0},
             weight_ce=1,
             weight_dice=1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ dependencies = [
     "imagecodecs",
     "yacs",
     "batchgeneratorsv2>=0.2",
-    "einops"
+    "einops",
+    "hiddenlayer"
 ]
 
 [project.urls]


### PR DESCRIPTION
1) Multi gpu and multi node training using DDP.
2) Use Zero optimizer to reduce memory footprint.
3) Batch size and num epoch tuning to speed up model training.
4) Code modifications to split training and validation datasets among available nodes.
5) Code modifications for torchrun compatibility such that each Python process runs on one gpu and support [Pytorch Elastic](https://pytorch.org/docs/stable/distributed.elastic.html)
6) Testing Amazon FSx for cluster to load and store model artifacts and checkpoints.